### PR TITLE
fix: types hash max size warning

### DIFF
--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -25,7 +25,9 @@ http {
   gzip                    on;
   gzip_types              text/plain application/json image/svg+xml;
   gzip_min_length         1000;
-
+  
+  types_hash_max_size     4096;
+  
   sendfile                on;
 
   server {


### PR DESCRIPTION
Warning on `systemctl status nginx`

http://nginx.org/en/docs/hash.html
https://wiki.archlinux.org/title/nginx